### PR TITLE
Add Tests folder with cmocka template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ TARGET_EXEC := corewar
 BUILD_DIR := ./build
 SRC_DIRS := ./src
 INCLUDE_DIR := -I ./include
+TEST_DIR := ./tests
 
 # Determine the platform
 UNAME_S := $(shell uname -s)
@@ -37,3 +38,7 @@ clean:
 
 fclean: clean
 	$(RM) corewar
+
+# Removes all executable files with _test prefix in tests folder
+tclean:
+	$(RM) $(TEST_DIR)/*_test

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,15 @@ $(BUILD_DIR)/%.c.o: %.c
 	mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@
 
+test: testBuildDir sample_test
+	$(TEST_DIR)/build/sample_test
+
+testBuildDir:
+	mkdir -p $(TEST_DIR)/build
+
+sample_test:
+	$(CC) $(TEST_DIR)/sample_test.c -o $(TEST_DIR)/build/sample_test -l cmocka
+
 .PHONY: clean
 clean:
 	$(RM) -r $(BUILD_DIR)
@@ -39,6 +48,6 @@ clean:
 fclean: clean
 	$(RM) corewar
 
-# Removes all executable files with _test prefix in tests folder
+# Delete the build folder containing the test executable files in tests
 tclean:
-	$(RM) $(TEST_DIR)/*_test
+	$(RM) -rf $(TEST_DIR)/build

--- a/tests/cmocka_template.c
+++ b/tests/cmocka_template.c
@@ -1,0 +1,15 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+static void UNIT_TEST_NAME(void **state) {
+
+}
+
+int main(void) {
+  const struct CMUnitTest tests[] = {
+    cmocka_unit_test(UNIT_TEST_NAME),
+  };
+  return cmocka_run_group_tests_name("CHANGE NAME", tests, NULL, NULL);
+}

--- a/tests/sample_test.c
+++ b/tests/sample_test.c
@@ -1,0 +1,24 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+static void compare_integer_pass(void **state) {
+  int i = 4;
+
+  assert_int_equal(i, 4);
+}
+
+static void compare_integer_failure(void **state) {
+  int i = 4;
+
+  assert_int_not_equal(i, 5);
+}
+
+int main(void) {
+  const struct CMUnitTest tests[] = {
+    cmocka_unit_test(compare_integer_pass),
+    cmocka_unit_test(compare_integer_failure),
+  };
+  return cmocka_run_group_tests_name("compare integer tests", tests, NULL, NULL);
+}


### PR DESCRIPTION
Add a `tests` folder that includes a cmocka template file.

Add a `tclean` target to remove all executable files in the test folder.